### PR TITLE
Read SECRET_KEY from environment variables

### DIFF
--- a/djangosite/djangosite/settings.py
+++ b/djangosite/djangosite/settings.py
@@ -8,7 +8,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'rbyn^-8i*r)qg%i%&kn&(^x$74wsb=b@)gjj%%*uu0_431dki2'
+SECRET_KEY = os.getenv('SECRET_KEY', '')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
For Issue: https://github.com/Mandelliant/nextbook-django/issues/61
It should now read SECRET_KEY from environment variables and if one is not found then it is set to an empty string.